### PR TITLE
ci(docs): validate .continue/config.yaml + link check

### DIFF
--- a/.github/workflows/continue-guard.yml
+++ b/.github/workflows/continue-guard.yml
@@ -1,0 +1,27 @@
+name: Continue Guard
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  validate-continue-and-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: pip install pyyaml
+
+      - name: Validate .continue/config.yaml
+        run: make check-continue-config
+
+      - name: Link check (docs + README)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --accept 200,206,429 "docs/**/*.md" "README.md"

--- a/Makefile
+++ b/Makefile
@@ -253,3 +253,7 @@ docs-verify:
 .PHONY: test-continue
 test-continue:
 	@pytest -q tests/test_chat_completions.py
+
+.PHONY: check-continue-config
+check-continue-config:
+	python3 scripts/validate_continue_config.py

--- a/scripts/validate_continue_config.py
+++ b/scripts/validate_continue_config.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import sys, os, argparse
+try:
+    import yaml  # PyYAML
+except Exception as e:
+    print("PyYAML é obrigatório: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REQ_ROLES = {"chat","autocomplete","edit","apply"}
+
+def validate(path: str) -> list[str]:
+    errs = []
+    if not os.path.exists(path):
+        return [f"missing {path}"]
+    with open(path, "r", encoding="utf-8") as f:
+        d = yaml.safe_load(f) or {}
+    # models
+    models = d.get("models") or []
+    m = next((x for x in models if (x or {}).get("name") == "router-auto"), None)
+    if not m:
+        errs.append("models: router-auto model missing")
+    else:
+        if m.get("provider") != "openai":
+            errs.append("models.router-auto.provider must be 'openai'")
+        if m.get("model") != "router-auto":
+            errs.append("models.router-auto.model must be 'router-auto'")
+        api_base = str(m.get("apiBase",""))
+        if not api_base.endswith("/v1"):
+            errs.append("models.router-auto.apiBase must end with '/v1'")
+        roles = set(m.get("roles") or [])
+        missing_roles = sorted(list(REQ_ROLES - roles))
+        if missing_roles:
+            errs.append(f"models.router-auto.roles missing: {', '.join(missing_roles)}")
+    # agent
+    a = d.get("agent") or {}
+    for k in ["chatModel","editModel","applyModel","autocompleteModel"]:
+        if a.get(k) != "router-auto":
+            errs.append(f"agent.{k} must be 'router-auto'")
+    # MCP
+    mcps = d.get("mcpServers") or []
+    if not any((s or {}).get("name") == "ai_router_mcp" for s in mcps):
+        errs.append("mcpServers: ai_router_mcp missing")
+    return errs
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--path", default=".continue/config.yaml")
+    args = p.parse_args()
+    errs = validate(args.path)
+    if errs:
+        print("\n".join(errs))
+        sys.exit(1)
+    print("continue-config: OK")
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Adds a validator for .continue/config.yaml, a Makefile target (check-continue-config), and a GitHub Action to run the validator and a docs link check on PRs and main pushes.