### PR TITLE
ci(continue): strengthen validator (apiKey + MCP command/args) and tweak lychee args

### DIFF
--- a/.github/workflows/continue-guard.yml
+++ b/.github/workflows/continue-guard.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -24,4 +25,4 @@ jobs:
       - name: Link check (docs + README)
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --accept 200,206,429 "docs/**/*.md" "README.md"
+          args: --no-progress --exclude-mail --accept 200,206,429 "docs/**/*.md" "README.md"


### PR DESCRIPTION
Validator endurecido: exige apiKey (existência apenas) no models.router-auto e checa command/args no MCP ai_router_mcp. Workflow atualizado com --exclude-mail no lychee para reduzir flakiness.